### PR TITLE
renames Czech Republic to the new official name Czechia for cn, en, es, fr, ru, th and tw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Freeze regions arrays (j15e)
 * Add Rangpur bibha, Bangladesh (ecbypi)
 * Add Telegana, India (ecbypi)
+* Rename Czech Republic to Czechia (and its translations) for cn, en, es, fr, ru, th, tw
 
 ### 1.0.2
 * Replace use of UnicodeUtils with ActiveSupport (eikes)

--- a/locale/base/en/world.yml
+++ b/locale/base/en/world.yml
@@ -223,7 +223,7 @@ en:
       official_name: Republic of Cyprus
     cz:
       common_name: 
-      name: Czech Republic
+      name: Czechia
       official_name: 
     de:
       common_name: 

--- a/locale/overlay/cn/world.yml
+++ b/locale/overlay/cn/world.yml
@@ -227,7 +227,7 @@ cn:
       official_name: !!null
     cz:
       common_name: !!null
-      name: 捷克共和国
+      name: 捷克
       official_name: !!null
     de:
       common_name: !!null

--- a/locale/overlay/es/world.yml
+++ b/locale/overlay/es/world.yml
@@ -227,7 +227,7 @@ es:
       official_name: !!null 
     cz:
       common_name: !!null 
-      name: República Checa
+      name: Chequia
       official_name: !!null 
     de:
       common_name: !!null 

--- a/locale/overlay/fr/world.yml
+++ b/locale/overlay/fr/world.yml
@@ -224,7 +224,7 @@ fr:
     cz:
       common_name: !!null
       name: Tchéquie
-      official_name: République tchèque
+      official_name: Tchéquie (la)
     de:
       common_name: !!null
       name: Allemagne

--- a/locale/overlay/ru/world.yml
+++ b/locale/overlay/ru/world.yml
@@ -231,7 +231,7 @@ ru:
       official_name: !!null 
     cz:
       common_name: !!null 
-      name: Чешская республика
+      name: Чеxия
       official_name: !!null 
     de:
       common_name: !!null 

--- a/locale/overlay/th/word.yml
+++ b/locale/overlay/th/word.yml
@@ -223,7 +223,7 @@ th:
       official_name: Republic of Cyprus
     cz:
       common_name: 
-      name: Czech Republic
+      name: Czechia
       official_name: 
     de:
       common_name: 

--- a/locale/overlay/tw/world.yml
+++ b/locale/overlay/tw/world.yml
@@ -215,7 +215,7 @@ tw:
       official_name: !!null
     cz:
       common_name: !!null
-      name: 捷克共和國
+      name: 捷克
       official_name: !!null
     de:
       common_name: !!null


### PR DESCRIPTION

All in the title.
The new official name of the Czech Republic is Czechia.
I've taken the translations from http://unstats.un.org/unsd/geoinfo/geonames/
Which provides translations of countries in the 6 official UN languages. I've not touched other languages as I'm not an expert, many of them already used a form similar to the new one so they may never change.