### PR TITLE
Fixed code for Telangana state in India, added locale entry

### DIFF
--- a/iso_data/overlay/world/in.yml
+++ b/iso_data/overlay/world/in.yml
@@ -1,3 +1,3 @@
 ---
-- code: TS
+- code: TG
   type: state

--- a/locale/base/en/world/in.yml
+++ b/locale/base/en/world/in.yml
@@ -66,6 +66,8 @@ en:
         name: Tamil Nadu
       tr:
         name: Tripura
+      tg:
+        name: Telangana
       up:
         name: Uttar Pradesh
       ut:

--- a/locale/base/en/world/in.yml
+++ b/locale/base/en/world/in.yml
@@ -66,8 +66,6 @@ en:
         name: Tamil Nadu
       tr:
         name: Tripura
-      tg:
-        name: Telangana
       up:
         name: Uttar Pradesh
       ut:

--- a/locale/overlay/en/world/in.yml
+++ b/locale/overlay/en/world/in.yml
@@ -2,5 +2,5 @@
 en:
   world:
     in:
-      ts:
+      tg:
         name: Telangana


### PR DESCRIPTION
Corrected ISO code for Telangana state in India - https://en.wikipedia.org/wiki/ISO_3166-2:IN#Current_codes