### PR TITLE
Add Bermuda parishes

### DIFF
--- a/iso_data/overlay/world/bm.yml
+++ b/iso_data/overlay/world/bm.yml
@@ -1,0 +1,19 @@
+---
+- code: 'DEV'
+  type: parish
+- code: 'HAM'
+  type: parish
+- code: 'PAG'
+  type: parish
+- code: 'PEM'
+  type: parish
+- code: 'SGE'
+  type: parish
+- code: 'SAN'
+  type: parish
+- code: 'SMI'
+  type: parish
+- code: 'SOU'
+  type: parish
+- code: 'WAR'
+  type: parish

--- a/locale/overlay/en/world/bm.yml
+++ b/locale/overlay/en/world/bm.yml
@@ -1,0 +1,22 @@
+---
+en:
+  world:
+    bm:
+      dev:
+        name: Devenshire
+      ham:
+        name: Hamilton
+      pag:
+        name: Paget
+      pem:
+        name: Pembroke
+      sge:
+        name: Saint George's
+      san:
+        name: Sandys
+      smi:
+        name: Smiths
+      sou:
+        name: Southampton
+      war:
+        name: Warwick


### PR DESCRIPTION
Adds support for the 9 parishes of Bermuda.

The [official ISO 3166 for Bermuda](https://www.iso.org/obp/ui/#iso:code:3166:BM) confirms there are 9 parishes, but states, "which is not relevant for this part of ISO 3166". 

I was able  to get the ISO codes for the parishes from http://www.statoids.com/ubm.html:
<img width="491" alt="statoids-bermuda" src="https://user-images.githubusercontent.com/1090773/27433056-86bc308e-5718-11e7-964a-8961d04f23f7.png">

This same data is also in ["Administrative Subdivisions of Countries: A Comprehensive World Reference" by Gwillim Law](https://books.google.com/books?id=nXCeCQAAQBAJ&pg=PA53&lpg=PA53).

I tested these changes from the console:
```
» bundle exec rake console
2.2.3 :001 > bermuda = Carmen::Country.coded('bm')
 => <#Carmen::Country name="Bermuda">
2.2.3 :002 > bermuda.subregions.map(&:name).sort
 => ["Devenshire", "Hamilton", "Paget", "Pembroke", "Saint George's", "Sandys", "Smiths", "Southampton", "Warwick"]
```