### PR TITLE
Fix data update script

### DIFF
--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib,iso_data,locale}/**/*") + %w(MIT-LICENSE README.md CHANGELOG.md)
 
   s.add_development_dependency('minitest', ["= 2.6.1"])
-  s.add_development_dependency('nokogiri')
   s.add_development_dependency('rake', '0.9.2.2')
   s.add_development_dependency('i18n')
   s.add_dependency('activesupport', '>= 3.0.0')

--- a/script/update_data.rb
+++ b/script/update_data.rb
@@ -1,4 +1,3 @@
-require 'nokogiri'
 require 'yaml'
 require 'pathname'
 

--- a/script/update_data.rb
+++ b/script/update_data.rb
@@ -99,9 +99,7 @@ regions_json = JSON.parse(File.read(region_data_path))['3166-2']
 warnings = []
 
 # Group the regions by their country code
-regions_json.group_by { |h| h['code'].split(/-| /)[0] }.each do |country_regions|
-  country_code = country_regions[0].downcase
-  country_subregions = country_regions[1]
+regions_json.group_by { |h| h['code'].split(/-| /)[0] }.each do |country_code, country_subregions|
   regions = []
 
   # Hash of { <parent_region_code>: [<list of subregions>], ... }
@@ -111,7 +109,7 @@ regions_json.group_by { |h| h['code'].split(/-| /)[0] }.each do |country_regions
 
   country_subregions.each do |subregion|
     data = {
-      'code' => subregion['code'].gsub(%r{^#{country_code.upcase}-}, ''),
+      'code' => subregion['code'].gsub(%r{^#{country_code}-}i, ''),
       'name' => subregion['name'],
       'type' => subregion['type'].downcase
     }
@@ -142,7 +140,7 @@ regions_json.group_by { |h| h['code'].split(/-| /)[0] }.each do |country_regions
   end
 
   sorted_regions = regions.sort_by {|e| e['code'] }
-  write_regions_to_path_as_yaml(sorted_regions, "world/#{country_code}")
+  write_regions_to_path_as_yaml(sorted_regions, "world/#{country_code.downcase}")
   print '.'
 end
 


### PR DESCRIPTION
Running this locally generates data that appears to be correct. After going through some of the countries and their updated subregions "by hand" I am confident that this is working as expected. For example, running this locally will pick up and correctly build YAML for the [changes to France's subregions as described in this issue](https://github.com/carmen-ruby/carmen/issues/228).

### Commit message
The location and format of the ISO data has changed. The data is
available in plain JSON.

The fundamental data structure that is used by Carmen to build the YAML
files is not changed by this PR. This only tweaks the intermediary
step of getting the information from the Debian repository into the data
structure that Carmen needs.

ISO country data:
https://anonscm.debian.org/git/pkg-isocodes/iso-codes.git/plain/data/iso_3166-1.json

ISO region data:
https://anonscm.debian.org/git/pkg-isocodes/iso-codes.git/plain/data/iso_3166-2.json