### PR TITLE
Revert removing Puerto Rico as a country code

### DIFF
--- a/iso_data/overlay/world.yml
+++ b/iso_data/overlay/world.yml
@@ -1,3 +1,0 @@
----
-- alpha_2_code: PR
-  _enabled: false

--- a/spec/carmen/sanity_spec.rb
+++ b/spec/carmen/sanity_spec.rb
@@ -28,11 +28,6 @@ describe "default data sanity check" do
     il.name.must_equal('Illinois')
   end
 
-  it "observes region data in the overlay directory" do
-    pr = Carmen::Country.coded('PR')
-    pr.must_equal nil
-  end
-
   it "observes locale data in the overlay directory" do
     tw = Carmen::Country.coded('TW')
     tw.name.must_equal('Taiwan')


### PR DESCRIPTION
According to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements), 'PR' is a country code for Puerto Rico.
This was removed because it is an unincorporated territory of the United
States - which is irrelevant. If the ISO lists 'PR' as a valid country
code, we should treat it as such.

Resolves #214.