### PR TITLE
Remove carmen-rails notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Carmen features the following:
 * Complete countries & regions data from the iso-codes Debian package
 * A sane approach to internationalization
 
-## Ruby on Rails
-
-If you are using Carmen with Rails, you should check out the [carmen-rails](http://github.com/jim/carmen-rails) library.
-
 # How to Use Carmen
 
 Carmen is designed to make it easy to access Country and region data.


### PR DESCRIPTION
The carmen-rails library has not been updated in four years, and was
stable for Rails 3. We shouldn't be directing Rails users to that
repository. If there ever comes a time that it is maintained again we
can add it back.