### PR TITLE
Update the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+Before submitting a PR that modifies geographical data, please read the [Wiki on
+how to do this
+properly](https://github.com/carmen-ruby/carmen/wiki/Contributing-Data). This
+will save everyone a lot of time, and get your PR merged quicker!
+
 For non-trivial PRs, please add an entry to the CHANGELOG (following the convention in place).
 
 If the changes are geography related (overlay/locale modifications) place the entry under "Geographic Modifications".
@@ -6,6 +11,13 @@ Please follow this format _exactly_:
 
 `[#<pr-number>] <PR description _without_ an ending period> ([@<github-handle>](<github-profile>))`
 
+__Please replace the text above with a summary of your changes__
+
 ------------------------------------------
 
-**Please remove the text in this template before submitting your Pull Request**
+Before submitting the PR please make sure that you have done the following:
+
+* [ ] I have read the [Wiki on how to make geographic
+  changes](https://github.com/carmen-ruby/carmen/wiki/Contributing-Data) if this
+  PR modifies geographic data
+* [ ] I have added a CHANGELOG entry if appropriate


### PR DESCRIPTION
Adds a quick (and hopefully polite) reminder to read the wiki on how to
make geographic changes if necessary.

This also adds a short checklist of things to do before submitting a PR.
