### PR TITLE
Update Moroccan regions and their sub regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### master (unreleased)
 
+##### Geographic Modifications
+* [#267](https://github.com/carmen-ruby/carmen/pull/267) Update Moroccan regions and subregions to match the new standard (after 2015), because of the absence of the new iso codes, I used the last two digit of the non-official [HASC](http://www.statoids.com/ihasc.html) codes.
+([@kainio](https://github.com/kainio))
+
 ### 1.1.1 (May 7, 2018)
 * [#250](https://github.com/carmen-ruby/carmen/pull/250) Add better fuzzy
   searching when using `Querying#named`. Calling this method with `fuzzy:

--- a/iso_data/overlay/world/ma.yml
+++ b/iso_data/overlay/world/ma.yml
@@ -1,0 +1,33 @@
+---
+- code: '01'
+  type: economic region
+- code: '02'
+  type: economic region
+- code: '03'
+  type: economic region
+- code: '04'
+  type: economic region
+- code: '05'
+  type: economic region
+- code: '06'
+  type: economic region
+- code: '07'
+  type: economic region
+- code: '08'
+  type: economic region
+- code: '09'
+  type: economic region
+- code: '10'
+  type: economic region
+- code: '11'
+  type: economic region
+- code: '12'
+  type: economic region
+- code: '13'
+  _enabled: false
+- code: '14'
+  _enabled: false
+- code: '15'
+  _enabled: false
+- code: '16'
+  _enabled: false

--- a/iso_data/overlay/world/ma/01.yml
+++ b/iso_data/overlay/world/ma/01.yml
@@ -1,0 +1,27 @@
+---
+- code: CHE
+  _enabled: false
+- code: FAH
+  _enabled: false
+- code: LAR
+  _enabled: false
+- code: TET
+  _enabled: false
+- code: TNG
+  _enabled: false
+- code: TA
+  type: prefecture
+- code: MF
+  type: prefecture
+- code: TE
+  type: province
+- code: FB
+  type: province
+- code: LA
+  type: province
+- code: AH
+  type: province
+- code: CH
+  type: province
+- code: OU
+  type: province

--- a/iso_data/overlay/world/ma/02.yml
+++ b/iso_data/overlay/world/ma/02.yml
@@ -1,0 +1,21 @@
+---
+- code: KEN
+  _enabled: false
+- code: SIK
+  _enabled: false
+- code: OA
+  type: prefecture
+- code: NA
+  type: province
+- code: DR
+  type: province
+- code: JE
+  type: province
+- code: BE
+  type: province
+- code: TA
+  type: province
+- code: GU
+  type: province
+- code: FI
+  type: province

--- a/iso_data/overlay/world/ma/03.yml
+++ b/iso_data/overlay/world/ma/03.yml
@@ -1,0 +1,25 @@
+---
+- code: HOC
+  _enabled: false
+- code: TAO
+  _enabled: false
+- code: TAZ
+  _enabled: false
+- code: FS
+  type: prefecture
+- code: ME
+  type: prefecture
+- code: EH
+  type: province
+- code: IF
+  type: province
+- code: ZM
+  type: province
+- code: SE
+  type: province
+- code: BO
+  type: province
+- code: TN
+  type: province
+- code: TZ
+  type: province

--- a/iso_data/overlay/world/ma/04.yml
+++ b/iso_data/overlay/world/ma/04.yml
@@ -1,0 +1,27 @@
+---
+- code: BER
+  _enabled: false
+- code: FIG
+  _enabled: false
+- code: JRA
+  _enabled: false
+- code: NAD
+  _enabled: false
+- code: OUJ
+  _enabled: false
+- code: TAI
+  _enabled: false
+- code: RA
+  type: prefecture
+- code: SA
+  type: prefecture
+- code: ST
+  type: prefecture
+- code: KE
+  type: province
+- code: KH
+  type: province
+- code: SK
+  type: province
+- code: SS
+  type: province

--- a/iso_data/overlay/world/ma/05.yml
+++ b/iso_data/overlay/world/ma/05.yml
@@ -1,0 +1,19 @@
+---
+- code: BOM
+  _enabled: false
+- code: FES
+  _enabled: false
+- code: MOU
+  _enabled: false
+- code: SEF
+  _enabled: false
+- code: BM
+  type: province
+- code: AZ
+  type: province
+- code: FB
+  type: province
+- code: KF
+  type: province
+- code: KB
+  type: province

--- a/iso_data/overlay/world/ma/06.yml
+++ b/iso_data/overlay/world/ma/06.yml
@@ -1,0 +1,30 @@
+---
+- code: ERR
+  _enabled: false
+- code: HAJ
+  _enabled: false
+- code: IFR
+  _enabled: false
+- code: KHN
+  _enabled: false
+- code: MEK
+  _enabled: false
+- code: CB
+  type: prefecture
+- code: MH
+  type: prefecture
+- code: EJ
+  type: province
+- code: NC
+  type: province
+- code: ME
+  type: province
+- code: BS
+  type: province
+- code: BR
+  type: province
+- code: SE
+  type: province
+- code: SB
+  type: province
+

--- a/iso_data/overlay/world/ma/07.yml
+++ b/iso_data/overlay/world/ma/07.yml
@@ -1,0 +1,26 @@
+---
+- code: KHE
+  _enabled: false
+- code: RAB
+  _enabled: false
+- code: SAL
+  _enabled: false
+- code: SKH
+  _enabled: false
+- code: MR
+  type: prefecture
+- code: CH
+  type: province
+- code: AH
+  type: province
+- code: EK
+  type: province
+- code: ES
+  type: province
+- code: RE
+  type: province
+- code: SA
+  type: province
+- code: YO
+  type: province
+  

--- a/iso_data/overlay/world/ma/08.yml
+++ b/iso_data/overlay/world/ma/08.yml
@@ -1,0 +1,19 @@
+---
+- code: CAS
+  _enabled: false
+- code: MED
+  _enabled: false
+- code: MOH
+  _enabled: false
+- code: NOU
+  _enabled: false
+- code: ER
+  type: province
+- code: OU
+  type: province
+- code: MI
+  type: province
+- code: TI
+  type: province
+- code: ZA
+  type: province

--- a/iso_data/overlay/world/ma/09.yml
+++ b/iso_data/overlay/world/ma/09.yml
@@ -1,0 +1,19 @@
+---
+- code: BES
+  _enabled: false
+- code: KHO
+  _enabled: false
+- code: SET
+  _enabled: false
+- code: AI
+  type: prefecture
+- code: IA
+  type: prefecture
+- code: CA
+  type: province
+- code: TR
+  type: province
+- code: TI
+  type: province
+- code: TT
+  type: province

--- a/iso_data/overlay/world/ma/10.yml
+++ b/iso_data/overlay/world/ma/10.yml
@@ -1,0 +1,13 @@
+---
+- code: JDI
+  _enabled: false
+- code: SAF
+  _enabled: false
+- code: GU
+  type: province
+- code: AZ
+  type: province
+- code: TN
+  type: province
+- code: SI
+  type: province

--- a/iso_data/overlay/world/ma/11.yml
+++ b/iso_data/overlay/world/ma/11.yml
@@ -1,0 +1,23 @@
+---
+- code: CHI
+  _enabled: false
+- code: ESI
+  _enabled: false
+- code: HAO
+  _enabled: false
+- code: KES
+  _enabled: false
+- code: MMD
+  _enabled: false
+- code: MMN
+  _enabled: false
+- code: SYB
+  _enabled: false
+- code: LA
+  type: province
+- code: BO
+  type: province
+- code: TA
+  type: province
+- code: ES
+  type: province

--- a/iso_data/overlay/world/ma/12.yml
+++ b/iso_data/overlay/world/ma/12.yml
@@ -1,0 +1,9 @@
+---
+- code: AZI
+  _enabled: false
+- code: BEM
+  _enabled: false
+- code: OE
+  type: province
+- code: AO
+  type: province

--- a/locale/overlay/en/world/ma.yml
+++ b/locale/overlay/en/world/ma.yml
@@ -1,0 +1,28 @@
+---
+en:
+  world:
+    ma:
+      '01':
+        name: Tanger-Tétouan-Al Hoceïma
+      '02':
+        name: L'Oriental
+      '03':
+        name: Fès-Meknès
+      '04':
+        name: Rabat-Salé-Kénitra
+      '05':
+        name: Béni Mellal-Khénifra
+      '06':
+        name: Casablanca-Settat
+      '07':
+        name: Marrakech-Safi
+      '08':
+        name: Drâa-Tafilalet
+      '09':
+        name: Souss-Massa
+      '10':
+        name: Guelmim-Oued Noun
+      '11':
+        name: Laâyoune-Sakia El Hamra
+      '12':
+        name: Dakhla-Oued Ed Dahab

--- a/locale/overlay/en/world/ma/01.yml
+++ b/locale/overlay/en/world/ma/01.yml
@@ -1,0 +1,22 @@
+---
+en:
+  world:
+    ma:
+      '01':
+        ch:
+          name: Chefchaouen
+        ou:
+          name: Ouezzane
+        la:
+          name: Larache
+        te:
+          name: Tétouan
+        ta:
+          name: Tanger-Assilah
+        mf:
+          name: M'diq-Fnideq
+        fb:
+          name: Fahs-Anjra
+        ah:
+          name: Al Hoceïma
+        

--- a/locale/overlay/en/world/ma/02.yml
+++ b/locale/overlay/en/world/ma/02.yml
@@ -1,0 +1,21 @@
+---
+en:
+  world:
+    ma:
+      '02':
+        oa:
+          name: Oujda-Angad
+        na:
+          name: Nador
+        dr:
+          name: Driouch
+        je:
+          name: Jerada
+        be:
+          name: Berkane
+        ta:
+          name: Taourirt
+        gu:
+          name: Guercif
+        fi:
+          name: Figuig

--- a/locale/overlay/en/world/ma/03.yml
+++ b/locale/overlay/en/world/ma/03.yml
@@ -1,0 +1,23 @@
+---
+en:
+  world:
+    ma:
+      '03':
+        fs:
+          name: Fès
+        me:
+          name: Meknès
+        eh:
+          name: El Hajeb
+        if:
+          name: Ifrane
+        zm:
+          name: Moulay Yaâcoub
+        se:
+          name: Séfrou
+        bo:
+          name: Boulemane
+        tn:
+          name: Taounate
+        tz:
+          name: Taza

--- a/locale/overlay/en/world/ma/04.yml
+++ b/locale/overlay/en/world/ma/04.yml
@@ -1,0 +1,19 @@
+---
+en:
+  world:
+    ma:
+      '04':
+        ra:
+          name: Rabat
+        sa:
+          name: Salé
+        st:
+          name: Skhirate-Témara
+        ke:
+          name: Kénitra
+        kh:
+          name: Khémisset
+        sk:
+          name: Sidi Kacem
+        ss:
+          name: Sidi Slimane

--- a/locale/overlay/en/world/ma/05.yml
+++ b/locale/overlay/en/world/ma/05.yml
@@ -1,0 +1,16 @@
+---
+en:
+  world:
+    ma:
+      '05':
+        bm:
+          name: Béni-Mellal
+        az:
+          name: Azilal
+        fb:
+          name: Fquih Ben Salah
+        kf:
+          name: Khénifra
+        kb:
+          name: Khouribga
+          

--- a/locale/overlay/en/world/ma/06.yml
+++ b/locale/overlay/en/world/ma/06.yml
@@ -1,0 +1,23 @@
+---
+en:
+  world:
+    ma:
+      '06':
+        cb:
+          name: Casablanca
+        mh:
+          name: Mohammédia
+        ej:
+          name: El Jadida
+        nc:
+          name: Nouaceur
+        me:
+          name: Médiouna
+        bs:
+          name: Benslimane
+        br:
+          name: Berrechid
+        se:
+          name: Settat
+        sb:
+          name: Sidi Bennour

--- a/locale/overlay/en/world/ma/07.yml
+++ b/locale/overlay/en/world/ma/07.yml
@@ -1,0 +1,21 @@
+---
+en:
+  world:
+    ma:
+      '07':
+        mr:
+          name: Marrakech
+        ch:
+          name: Chichaoua
+        ah:
+          name: Al Haouz
+        ek:
+          name: El Kelaâ des Sraghna
+        es:
+          name: Essaouira
+        re:
+          name: Rehamna
+        sa:
+          name: Safi
+        yo:
+          name: Youssoufia

--- a/locale/overlay/en/world/ma/08.yml
+++ b/locale/overlay/en/world/ma/08.yml
@@ -1,0 +1,15 @@
+---
+en:
+  world:
+    ma:
+      '08':
+        er:
+          name: Errachidia
+        ou:
+          name: Ouarzazate
+        mi:
+          name: Midelt
+        ti:
+          name: Tinghir
+        za:
+          name: Zagora

--- a/locale/overlay/en/world/ma/09.yml
+++ b/locale/overlay/en/world/ma/09.yml
@@ -1,0 +1,17 @@
+---
+en:
+  world:
+    ma:
+      '09':
+        ai:
+          name: Agadir Ida-Outanane
+        ia:
+          name: Inezgane-Aït Melloul
+        ca:
+          name: Chtouka-Aït Baha
+        tr:
+          name: Taroudant
+        ti:
+          name: Tiznit
+        tt:
+          name: Tata

--- a/locale/overlay/en/world/ma/10.yml
+++ b/locale/overlay/en/world/ma/10.yml
@@ -1,0 +1,13 @@
+---
+en:
+  world:
+    ma:
+      '10':
+        gu:
+          name: Guelmim
+        az:
+          name: Assa-Zag
+        tn:
+          name: Tan-Tan
+        si:
+          name: Sidi Ifni

--- a/locale/overlay/en/world/ma/11.yml
+++ b/locale/overlay/en/world/ma/11.yml
@@ -1,0 +1,13 @@
+---
+en:
+  world:
+    ma:
+      '11':
+        la:
+          name: Laâyoune
+        bo:
+          name: Boujdour
+        ta:
+          name: Tarfaya
+        es:
+          name: Es-Semara

--- a/locale/overlay/en/world/ma/12.yml
+++ b/locale/overlay/en/world/ma/12.yml
@@ -1,0 +1,9 @@
+---
+en:
+  world:
+    ma:
+      '12':
+        oe:
+          name: Oued Ed Dahab
+        ao:
+          name: Aousserd


### PR DESCRIPTION
Update Moroccan regions and subregions to match the new standard (after 2015), and because of the absence of the new iso codes, I used the last two digit of the non-official [HASC](http://www.statoids.com/ihasc.html) codes.

Fix: #225 

------------------------------------------

Before submitting the PR please make sure that you have done the following:

* [x] I have read the [Wiki on how to make geographic changes](https://github.com/carmen-ruby/carmen/wiki/Contributing-Data) if this PR modifies geographic data
* [x] I have added a CHANGELOG entry if appropriate
