### PR TITLE
Remove UK overlays for Middlesex and Wiltshire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### master (unreleased)
 
+##### Geographic Modifications
+* [#268](https://github.com/carmen-ruby/carmen/pull/268) Remove UK overlays for Middlesex and Wiltshire ([@manewitz](https://github.com/manewitz))
+
 ### 1.1.1 (May 7, 2018)
 * [#250](https://github.com/carmen-ruby/carmen/pull/250) Add better fuzzy
   searching when using `Querying#named`. Calling this method with `fuzzy:

--- a/iso_data/overlay/world/gb.yml
+++ b/iso_data/overlay/world/gb.yml
@@ -1,5 +1,0 @@
----
-- code: MDX
-  type: province
-- code: WIL
-  type: province

--- a/locale/overlay/en/world/gb.yml
+++ b/locale/overlay/en/world/gb.yml
@@ -1,8 +1,0 @@
----
-en:
-  world:
-    gb:
-      mdx:
-        name: Middlesex
-      wil:
-        name: Wiltshire


### PR DESCRIPTION
   This came up because we use carmen to populate a "subregion" dropdown that is loaded after a user selects a country. We had several people write in about the UK list not being accurate.

   [Middlesex](https://en.wikipedia.org/wiki/Middlesex) is a "Historic County" and [not ISO-recognized as a subregion](https://www.iso.org/obp/ui/#iso:code:3166:GB). [Wiltshire](https://en.wikipedia.org/wiki/Wiltshire) is a "Unitary Authority" and [already in the base library](https://github.com/carmen-ruby/carmen/blob/cd3e696c67c61d81850e1a057ade5abe12a66454/locale/overlay/en/world/gb.yml#L7-L8). Even if their classifications had been corrent, the overlays removed had placed them at the wrong level in the region/subregion yaml hierarchy.

   Before: 
   ```ruby
   > uk = Carmen::Country.named('United Kingdom')
   > uk.subregions.map(&:name).sort
   => [
       [0] "England",
       [1] "England and Wales",
       [2] "Great Britain",
       [3] "Middlesex",
       [4] "Northern Ireland",
       [5] "Scotland",
       [6] "United Kingdom",
       [7] "Wales; Cymru",
       [8] "Wiltshire"
   ]
   ```

   After:
   ```ruby
   > uk.subregions.map(&:name).sort
   => [
        [0] "England",
        [1] "England and Wales",
        [2] "Great Britain",
        [3] "Northern Ireland",
        [4] "Scotland",
        [5] "United Kingdom",
        [6] "Wales; Cymru",
      ]
   ```
   ------------------------------------------

   Before submitting the PR please make sure that you have done the following:

   * [X] I have read the [Wiki on how to make geographic changes](https://github.com/carmen-ruby/carmen/wiki/Contributing-Data) if this PR modifies geographic data
   * [X] I have added a CHANGELOG entry if appropriate
 