### PR TITLE
Change Macedonia to North Macedonia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### master (unreleased)
 
 ##### Geographic Modifications
+* [#270](https://github.com/carmen-ruby/carmen/pull/270) Update name of FYR of Macedonia to North Macedonia ([@szajbus](https://github.com/szajbus))
 * [#267](https://github.com/carmen-ruby/carmen/pull/267) Update Moroccan regions and subregions to match the new standard (after 2015), because of the absence of the new iso codes, I used the last two digit of the non-official [HASC](http://www.statoids.com/ihasc.html) codes.
 ([@kainio](https://github.com/kainio))
 * [#268](https://github.com/carmen-ruby/carmen/pull/268) Remove UK overlays for Middlesex and Wiltshire ([@manewitz](https://github.com/manewitz))

--- a/locale/overlay/bn/world.yml
+++ b/locale/overlay/bn/world.yml
@@ -575,8 +575,8 @@ bn:
       official_name: Republic of the Marshall Islands
     mk:
       common_name: !!null
-      name: ম্যাসেডোনিয়া, প্রজাতন্ত্র
-      official_name: The Former Yugoslav Republic of Macedonia
+      name: উত্তর ম্যাসেডোনিয়া
+      official_name: Republic of North Macedonia
     ml:
       common_name: !!null
       name: মালি

--- a/locale/overlay/en/world.yml
+++ b/locale/overlay/en/world.yml
@@ -13,3 +13,7 @@ en:
     ru:
       name: Russia
       official_name: Russian Federation
+    mk:
+      common_name:
+      name: North Macedonia
+      official_name: Republic of North Macedonia

--- a/locale/overlay/es/world.yml
+++ b/locale/overlay/es/world.yml
@@ -579,7 +579,7 @@ es:
       official_name: !!null 
     mk:
       common_name: !!null 
-      name: República de Macedonia
+      name: Macedonia del Norte
       official_name: !!null 
     ml:
       common_name: !!null 

--- a/locale/overlay/it/world.yml
+++ b/locale/overlay/it/world.yml
@@ -579,7 +579,7 @@ it:
       official_name: !!null
     mk:
       common_name: !!null
-      name: Macedonia
+      name: Macedonia del Nord
       official_name: !!null
     ml:
       common_name: !!null

--- a/locale/overlay/pl/world.yml
+++ b/locale/overlay/pl/world.yml
@@ -563,7 +563,7 @@ pl:
       official_name: !!null 
     mk:
       common_name: !!null 
-      name: Macedonia, Była Jugosłowiańska Republika
+      name: Macedonia Północna
       official_name: !!null 
     ml:
       common_name: !!null 

--- a/locale/overlay/th/world.yml
+++ b/locale/overlay/th/world.yml
@@ -575,8 +575,8 @@ th:
       official_name: Republic of the Marshall Islands
     mk:
       common_name: 
-      name: Macedonia, Republic of
-      official_name: The Former Yugoslav Republic of Macedonia
+      name: North Macedonia
+      official_name: Republic of North Macedonia
     ml:
       common_name: 
       name: Mali


### PR DESCRIPTION
In February 2019 the former Yugoslav Republic of Macedonia officially changed its name to "Republic of North Macedonia".

This PR updates the country name.