### PR TITLE
Use the most recent version of minitest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
   - 2.3.0
+  - 2.4.0
+  - 2.5.0
+  - 2.6.0
   - ruby-head
 before_install:
   - gem install bundler

--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.files = Dir.glob("{lib,iso_data,locale}/**/*") + %w(MIT-LICENSE README.md CHANGELOG.md)
 
-  s.add_development_dependency('minitest', ["= 2.6.1"])
   s.add_development_dependency('rake', '0.9.2.2')
   s.add_development_dependency('i18n')
   s.add_dependency('activesupport', '>= 3.0.0')

--- a/spec/carmen/country_spec.rb
+++ b/spec/carmen/country_spec.rb
@@ -32,7 +32,7 @@ describe Carmen::Country do
 
     it "provides case-sensitive searches optionally" do
       oceania = Carmen::Country.named('oCeAnIa', :case => true)
-      oceania.must_equal nil
+      assert_nil(oceania)
       oceania = Carmen::Country.named('Oceania', :case => true)
       oceania.instance_of?(Carmen::Country).must_equal true
       oceania.name.must_equal 'Oceania'

--- a/spec/carmen/overlay_spec.rb
+++ b/spec/carmen/overlay_spec.rb
@@ -30,7 +30,7 @@ describe "Data overlaying" do
 
   it 'removes elements that have _enabled set to false' do
     Carmen::World.instance.subregions.size.must_equal(3)
-    Carmen::Country.named('Eurasia').must_equal nil
+    assert_nil(Carmen::Country.named('Eurasia'))
   end
 
 end

--- a/spec/carmen/region_spec.rb
+++ b/spec/carmen/region_spec.rb
@@ -80,7 +80,7 @@ describe Carmen::Region do
 
     it "can find subregions optionally case-sensitively" do
       oceania = @world.subregions.named('oCeAnIa', :case => true)
-      oceania.must_equal nil
+      assert_nil(oceania)
       oceania = @world.subregions.named('Oceania', :case => true)
       oceania.instance_of?(Carmen::Country).must_equal true
       oceania.name.must_equal 'Oceania'
@@ -112,11 +112,11 @@ describe Carmen::Region do
     end
 
     it 'handles querying for a nil code safely' do
-      @world.subregions.coded(nil).must_equal nil
+      assert_nil(@world.subregions.coded(nil))
     end
 
     it 'handles querying for a nil name safely' do
-      @world.subregions.named(nil).must_equal nil
+      assert_nil(@world.subregions.named(nil))
     end
 
     describe 'unicode character handling' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require 'minitest/unit'
-require 'minitest/spec'
 require 'minitest/autorun'
 
 require 'bundler/setup'


### PR DESCRIPTION
We were asking for 2.6.1 specifically which was released in September
2001. We have a relatively basic test suite and I'm only seeing a few
deprecation warnings when I upgrade locally.

Our PR Travis checks were failing when running 2.6.1.

I would have split the last commit into a separate PR to make it clear that we aren't supporting EOL versions, but all of these changes are needed to get a green status check.