### PR TITLE
Fix normalize deprecation warning

### DIFF
--- a/lib/carmen/querying.rb
+++ b/lib/carmen/querying.rb
@@ -32,15 +32,20 @@ module Carmen
     def named(name, options={})
       case_fold = !options[:case] && name.respond_to?(:each_codepoint)
       # These only need to be built once
-      name = case_fold ? name.mb_chars.downcase.normalize : name
+      name = case_fold ? normalise_name(name) : name
       # For now, "fuzzy" just means substring, optionally case-insensitive (the second argument looks for nil, not falseness)
       regexp = options[:fuzzy] ? Regexp.new(name.split(/[-'\s]/).join("[-'\s]"), options[:case] ? nil : true) : nil
-      
+
       query_collection.find do |region|
-        found_literal = name === (case_fold && region.name ? region.name.mb_chars.downcase.normalize : region.name)
+        found_literal = name === (case_fold && region.name ? normalise_name(region.name) : region.name)
         found_literal || options[:fuzzy] && regexp === region.name
       end
     end
 
+    private
+
+    def normalise_name(name)
+      name.mb_chars.downcase.unicode_normalize(:nfkc)
+    end
   end
 end


### PR DESCRIPTION
In activesupport 6.1 the `normalize` method will be deprecated 

`DEPRECATION WARNING: ActiveSupport::Multibyte::Chars#normalize is deprecated and will be removed from Rails 6.1. Use #unicode_normalize(:nfkc) instead.`

This PR simply applies the suggested change to use `String::unicode_normalize` which was introduced in Ruby 2.2, which by the look of the travis config you assume to be > 2.3 anyway