### PR TITLE
Gemfile: use https:// to connect to rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
This is a trivial change: use `https` to connect to rubygems.org.