### PR TITLE
Avoid all Minitest deprecation warnings

### DIFF
--- a/spec/carmen/country_spec.rb
+++ b/spec/carmen/country_spec.rb
@@ -8,7 +8,7 @@ describe Carmen::Country do
     end
 
     it "provides access to all countries" do
-      @countries.size.must_equal 3
+      _(@countries.size).must_equal 3
     end
 
     it "denies modification of countries" do
@@ -21,27 +21,27 @@ describe Carmen::Country do
   describe "API for finding countries by name" do
     it "provides exact matching" do
       eastasia = Carmen::Country.named('Eastasia')
-      eastasia.instance_of?(Carmen::Country).must_equal true
+      _(eastasia.instance_of?(Carmen::Country)).must_equal true
     end
 
     it "provides case-insensitive searches by default" do
       eurasia = Carmen::Country.named('eUrAsIa')
-      eurasia.instance_of?(Carmen::Country).must_equal true
-      eurasia.name.must_equal 'Eurasia'
+      _(eurasia.instance_of?(Carmen::Country)).must_equal true
+      _(eurasia.name).must_equal 'Eurasia'
     end
 
     it "provides case-sensitive searches optionally" do
       oceania = Carmen::Country.named('oCeAnIa', :case => true)
       assert_nil(oceania)
       oceania = Carmen::Country.named('Oceania', :case => true)
-      oceania.instance_of?(Carmen::Country).must_equal true
-      oceania.name.must_equal 'Oceania'
+      _(oceania.instance_of?(Carmen::Country)).must_equal true
+      _(oceania.name).must_equal 'Oceania'
     end
 
     it "provides fuzzy (substring) matching optionally" do
       eastasia = Carmen::Country.named('East', :fuzzy => true)
-      eastasia.instance_of?(Carmen::Country).must_equal true
-      eastasia.name.must_equal 'Eastasia'
+      _(eastasia.instance_of?(Carmen::Country)).must_equal true
+      _(eastasia.name).must_equal 'Eastasia'
     end
 
   end
@@ -50,40 +50,40 @@ describe Carmen::Country do
     describe 'Universal finder method' do
       it 'provides an API for finding countries by 2-symbol code' do
         eurasia = Carmen::Country.coded('EU')
-        eurasia.instance_of?(Carmen::Country).must_equal true
-        eurasia.name.must_equal 'Eurasia'
+        _(eurasia.instance_of?(Carmen::Country)).must_equal true
+        _(eurasia.name).must_equal 'Eurasia'
       end
 
       it 'provides an API for finding countries by 3-symbol code' do
         eastasia = Carmen::Country.coded('EST')
-        eastasia.instance_of?(Carmen::Country).must_equal true
-        eastasia.name.must_equal 'Eastasia'
+        _(eastasia.instance_of?(Carmen::Country)).must_equal true
+        _(eastasia.name).must_equal 'Eastasia'
       end
 
       it 'provides an API for finding countries by numeric code' do
         oceania = Carmen::Country.coded('001')
-        oceania.instance_of?(Carmen::Country).must_equal true
-        oceania.name.must_equal 'Oceania'
+        _(oceania.instance_of?(Carmen::Country)).must_equal true
+        _(oceania.name).must_equal 'Oceania'
       end
     end
 
     describe 'Finder methods for searching by each attribute' do
       it 'provides an API for finding countries by 2-symbol code' do
         eurasia = Carmen::Country.alpha_2_coded('EU')
-        eurasia.instance_of?(Carmen::Country).must_equal true
-        eurasia.name.must_equal 'Eurasia'
+        _(eurasia.instance_of?(Carmen::Country)).must_equal true
+        _(eurasia.name).must_equal 'Eurasia'
       end
 
       it 'provides an API for finding countries by 3-symbol code' do
         eastasia = Carmen::Country.alpha_3_coded('EST')
-        eastasia.instance_of?(Carmen::Country).must_equal true
-        eastasia.name.must_equal 'Eastasia'
+        _(eastasia.instance_of?(Carmen::Country)).must_equal true
+        _(eastasia.name).must_equal 'Eastasia'
       end
 
       it 'provides an API for finding countries by numeric code' do
         oceania = Carmen::Country.numeric_coded('001')
-        oceania.instance_of?(Carmen::Country).must_equal true
-        oceania.name.must_equal 'Oceania'
+        _(oceania.instance_of?(Carmen::Country)).must_equal true
+        _(oceania.name).must_equal 'Oceania'
       end
     end
   end
@@ -94,44 +94,44 @@ describe Carmen::Country do
     end
 
     it "is of type :country" do
-      @oceania.type.must_equal 'country'
+      _(@oceania.type).must_equal 'country'
     end
 
     it "has a name" do
-      @oceania.name.must_equal 'Oceania'
+      _(@oceania.name).must_equal 'Oceania'
     end
 
     it "has an official name" do
-      @oceania.official_name.must_equal 'The Superstate of Oceania'
+      _(@oceania.official_name).must_equal 'The Superstate of Oceania'
     end
+
     it "has a common name" do
-      @oceania.common_name.must_equal 'Oceania'
+      _(@oceania.common_name).must_equal 'Oceania'
     end
 
     it "has a 2 character code" do
-      @oceania.alpha_2_code.must_equal 'OC'
+      _(@oceania.alpha_2_code).must_equal 'OC'
     end
 
     it "has a 3 character code" do
-      @oceania.alpha_3_code.must_equal 'OCE'
+      _(@oceania.alpha_3_code).must_equal 'OCE'
     end
 
     it "has code as an alias to alpha_2_code" do
-      @oceania.code.must_equal 'OC'
+      _(@oceania.code).must_equal 'OC'
     end
 
     it "has a numeric code" do
-      @oceania.numeric_code.must_equal '001'
+      _(@oceania.numeric_code).must_equal '001'
     end
 
     it "has the world as a parent" do
-      @oceania.parent.must_equal Carmen::World.instance
+      _(@oceania.parent).must_equal Carmen::World.instance
     end
 
     it 'has a reasonable inspect value' do
-      @oceania.inspect.must_equal '<#Carmen::Country name="Oceania">'
+      _(@oceania.inspect).must_equal '<#Carmen::Country name="Oceania">'
     end
   end
-
 
 end

--- a/spec/carmen/i18n_spec.rb
+++ b/spec/carmen/i18n_spec.rb
@@ -7,7 +7,7 @@ describe 'Carmen I18n defaults' do
   it "sets an instance of I18n::Simple as the default backend" do
     backend = Carmen.i18n_backend
 
-    backend.instance_of?(Carmen::I18n::Simple).must_equal true
+    _(backend.instance_of?(Carmen::I18n::Simple)).must_equal true
   end
 
 end
@@ -20,13 +20,13 @@ describe "I18n::Simple" do
   end
 
   it 'knows which locales are available' do
-    @i18n.available_locales.must_equal ['de', 'en']
+    _(@i18n.available_locales).must_equal ['de', 'en']
   end
 
   it "loads and merges yaml files" do
-    @i18n.t('world.oc.name').must_equal 'Oceania'
-    @i18n.t('world.oc.ao.name').must_equal 'Airstrip One'
-    @i18n.t('world.oc.ao.lo.name').must_equal 'London'
+    _(@i18n.t('world.oc.name')).must_equal 'Oceania'
+    _(@i18n.t('world.oc.ao.name')).must_equal 'Airstrip One'
+    _(@i18n.t('world.oc.ao.lo.name')).must_equal 'London'
   end
 
   describe "overlaying additional locale paths" do
@@ -41,11 +41,11 @@ describe "I18n::Simple" do
     end
 
     it 'can override the names of countries' do
-      @i18n.t('world.es.official_name').must_equal('The Wonderous Country of Eastasia')
+      _(@i18n.t('world.es.official_name')).must_equal('The Wonderous Country of Eastasia')
     end
 
     it 'can override the names of subregions' do
-      @i18n.t('world.oc.ao.name').must_equal('Airstrip Uno')
+      _(@i18n.t('world.oc.ao.name')).must_equal('Airstrip Uno')
     end
   end
 
@@ -61,23 +61,23 @@ describe "I18n::Simple" do
     end
 
     it 'retains existing locales' do
-      @i18n.available_locales.must_equal ['de', 'en', 'zz']
+      _(@i18n.available_locales).must_equal ['de', 'en', 'zz']
     end
 
     it 'stores the current locale' do
-      @i18n.locale.must_equal 'zz'
+      _(@i18n.locale).must_equal 'zz'
     end
 
     it 'can override the names of countries' do
-      @i18n.t('world.es.official_name').must_equal('The Zonderous Zountry of Zeastasia')
+      _(@i18n.t('world.es.official_name')).must_equal('The Zonderous Zountry of Zeastasia')
     end
 
     it 'can override the names of subregions' do
-      @i18n.t('world.oc.ao.name').must_equal('Zairstrip Zuno')
+      _(@i18n.t('world.oc.ao.name')).must_equal('Zairstrip Zuno')
     end
 
     it 'falls back when a a locale is missing a value' do
-      @i18n.t('world.eu.official_name').must_equal('The Superstate of Eurasia')
+      _(@i18n.t('world.eu.official_name')).must_equal('The Superstate of Eurasia')
     end
   end
 
@@ -93,9 +93,8 @@ describe "I18n::Simple" do
     end
 
     it 'still has access to the base locale data' do
-      @i18n.t('world.eu.official_name').must_equal('Das großartige Staat von Eurasia')
+      _(@i18n.t('world.eu.official_name')).must_equal('Das großartige Staat von Eurasia')
     end
-
   end
 
 end

--- a/spec/carmen/overlay_spec.rb
+++ b/spec/carmen/overlay_spec.rb
@@ -12,24 +12,24 @@ describe "Data overlaying" do
 
   it 'finds elements that exist only in overlay files' do
     sealand = Carmen::Country.coded('SE')
-    sealand.instance_of?(Carmen::Country).must_equal true
-    sealand.type.must_equal('fort')
+    _(sealand.instance_of?(Carmen::Country)).must_equal true
+    _(sealand.type).must_equal('fort')
   end
 
   it 'still finds elements that exist only in gem files' do
     oceania = Carmen::Country.coded('OC')
-    oceania.instance_of?(Carmen::Country).must_equal true
-    oceania.type.must_equal('country')
+    _(oceania.instance_of?(Carmen::Country)).must_equal true
+    _(oceania.type).must_equal('country')
   end
 
   it 'still finds subregions that exist only in gem files' do
     oceania = Carmen::Country.coded('OC')
-    oceania.subregions?.must_equal true
-    oceania.subregions.named("Airstrip One").type.must_equal("province")
+    _(oceania.subregions?).must_equal true
+    _(oceania.subregions.named("Airstrip One").type).must_equal("province")
   end
 
   it 'removes elements that have _enabled set to false' do
-    Carmen::World.instance.subregions.size.must_equal(3)
+    _(Carmen::World.instance.subregions.size).must_equal(3)
     assert_nil(Carmen::Country.named('Eurasia'))
   end
 

--- a/spec/carmen/region_collection_spec.rb
+++ b/spec/carmen/region_collection_spec.rb
@@ -10,7 +10,7 @@ describe Carmen::RegionCollection do
   end
 
   it 'provides an API for filtering regions by type' do
-    @collection.typed('custom_type1').map(&:code).must_equal ['AA']
+    _(@collection.typed('custom_type1').map(&:code)).must_equal ['AA']
   end
 
 end

--- a/spec/carmen/region_spec.rb
+++ b/spec/carmen/region_spec.rb
@@ -10,23 +10,23 @@ describe Carmen::Region do
     end
 
     it 'has a reasonable inspect value' do
-      @airstrip_one.inspect.must_equal '<#Carmen::Region name="Airstrip One" type="province">'
+      _(@airstrip_one.inspect).must_equal '<#Carmen::Region name="Airstrip One" type="province">'
     end
     
     it 'has a reasonable explicit string conversion' do
-      "#{@airstrip_one}".must_equal 'Airstrip One'
+      _("#{@airstrip_one}").must_equal 'Airstrip One'
     end
 
     it "has the correct subregion path" do
-      @airstrip_one.subregion_data_path.must_equal "world/oc/ao.yml"
+      _(@airstrip_one.subregion_data_path).must_equal "world/oc/ao.yml"
     end
 
     it "knows if it has subregions" do
-      @airstrip_one.subregions?.must_equal true
+      _(@airstrip_one.subregions?).must_equal true
     end
 
     it "has a path" do
-      @airstrip_one.path.must_equal 'world.oc.ao'
+      _(@airstrip_one.path).must_equal 'world.oc.ao'
     end
 
     describe "subregions" do
@@ -45,19 +45,19 @@ describe Carmen::Region do
       end
 
       it "has a name" do
-        @london.name.must_equal "London"
+        _(@london.name).must_equal "London"
       end
 
       it "has a code" do
-        @london.code.must_equal 'LO'
+        _(@london.code).must_equal 'LO'
       end
 
       it "has a type" do
-        @london.type.must_equal 'city'
+        _(@london.type).must_equal 'city'
       end
 
       it "has a parent" do
-        @london.parent.must_equal @airstrip_one
+        _(@london.parent).must_equal @airstrip_one
       end
     end
   end
@@ -69,46 +69,46 @@ describe Carmen::Region do
 
     it 'can find subregions by exact name' do
       eastasia = @world.subregions.named('Eastasia')
-      eastasia.name.must_equal('Eastasia')
+      _(eastasia.name).must_equal('Eastasia')
     end
 
     it "can find subregions by case-insensitive search by default" do
       eurasia = @world.subregions.named('eUrAsIa')
-      eurasia.instance_of?(Carmen::Country).must_equal true
-      eurasia.name.must_equal 'Eurasia'
+      _(eurasia.instance_of?(Carmen::Country)).must_equal true
+      _(eurasia.name).must_equal 'Eurasia'
     end
 
     it "can find subregions optionally case-sensitively" do
       oceania = @world.subregions.named('oCeAnIa', :case => true)
       assert_nil(oceania)
       oceania = @world.subregions.named('Oceania', :case => true)
-      oceania.instance_of?(Carmen::Country).must_equal true
-      oceania.name.must_equal 'Oceania'
+      _(oceania.instance_of?(Carmen::Country)).must_equal true
+      _(oceania.name).must_equal 'Oceania'
     end
 
     it "can find subregions with fuzzy (substring) matching optionally" do
       eastasia = @world.subregions.named('East', :fuzzy => true)
-      eastasia.instance_of?(Carmen::Country).must_equal true
-      eastasia.name.must_equal 'Eastasia'
+      _(eastasia.instance_of?(Carmen::Country)).must_equal true
+      _(eastasia.name).must_equal 'Eastasia'
     end
 
     it 'can find subregions with dash or hyphen in name ' do
       @airstrip_one = Carmen::Country.coded('OC').subregions.named('Airstrip-One', :fuzzy => true)
-      "#{@airstrip_one}".must_equal 'Airstrip One'
+      _("#{@airstrip_one}").must_equal 'Airstrip One'
       @airstrip_two_without_dash = Carmen::Country.coded('OC').subregions.named('Airstrip Two', :fuzzy => true)
-      "#{@airstrip_two_without_dash}".must_equal 'Airstrip-Two'
+      _("#{@airstrip_two_without_dash}").must_equal 'Airstrip-Two'
       @airstrip_two = Carmen::Country.coded('OC').subregions.named('Airstrip-Two', :fuzzy => true)
-      "#{@airstrip_two}".must_equal 'Airstrip-Two'
+      _("#{@airstrip_two}").must_equal 'Airstrip-Two'
     end
 
     it 'can find subregions by name using a regex' do
       eastasia = @world.subregions.named(/Eastasia/)
-      eastasia.name.must_equal('Eastasia')
+      _(eastasia.name).must_equal('Eastasia')
     end
 
     it 'can find subregions by name using a case-insensitive regex' do
       eastasia = @world.subregions.named(/eastasia/i)
-      eastasia.name.must_equal('Eastasia')
+      _(eastasia.name).must_equal('Eastasia')
     end
 
     it 'handles querying for a nil code safely' do
@@ -130,14 +130,14 @@ describe Carmen::Region do
 
       it 'can find a country using unicode characters' do
         large = @world.subregions.named('Das großartige Staat von Eurasia')
-        large.instance_of?(Carmen::Country).must_equal true
-        large.name.must_equal('Das großartige Staat von Eurasia')
+        _(large.instance_of?(Carmen::Country)).must_equal true
+        _(large.name).must_equal('Das großartige Staat von Eurasia')
       end
 
       it 'can find a country using unicode characters' do
         large = @world.subregions.named('gross', :fuzzy => true)
-        large.instance_of?(Carmen::Country).must_equal true
-        large.name.must_equal('Das großartige Staat von Eurasia')
+        _(large.instance_of?(Carmen::Country)).must_equal true
+        _(large.name).must_equal('Das großartige Staat von Eurasia')
       end
 
     end
@@ -157,9 +157,9 @@ describe Carmen::Region do
     it 'does a comparison' do
       germany = SortTestRegion.new('name' => 'Germany')
       guatemala = SortTestRegion.new('name' => 'Guatemala')
-      (germany <=> guatemala).must_equal -1
-      (guatemala <=> germany).must_equal 1
-      (germany <=> germany).must_equal 0
+      _(germany <=> guatemala).must_equal -1
+      _(guatemala <=> germany).must_equal 1
+      _(germany <=> germany).must_equal 0
     end
   end
 end

--- a/spec/carmen/sanity_spec.rb
+++ b/spec/carmen/sanity_spec.rb
@@ -12,24 +12,24 @@ describe "default data sanity check" do
   end
 
   it "has 248 countries" do
-    Carmen::Country.all.size.must_equal 249
+    _(Carmen::Country.all.size).must_equal 249
   end
 
   it "can retrieve a country" do
     us = Carmen::Country.coded('US')
-    us.instance_of?(Carmen::Country).must_equal(true, "did not find USA")
-    us.name.must_equal('United States')
+    _(us.instance_of?(Carmen::Country)).must_equal(true, "did not find USA")
+    _(us.name).must_equal('United States')
   end
 
   it "can retrieve a state" do
     us = Carmen::Country.coded('US')
     il = us.subregions.coded('IL')
-    il.instance_of?(Carmen::Region).must_equal(true, "did not find Illinois")
-    il.name.must_equal('Illinois')
+    _(il.instance_of?(Carmen::Region)).must_equal(true, "did not find Illinois")
+    _(il.name).must_equal('Illinois')
   end
 
   it "observes locale data in the overlay directory" do
     tw = Carmen::Country.coded('TW')
-    tw.name.must_equal('Taiwan')
+    _(tw.name).must_equal('Taiwan')
   end
 end

--- a/spec/carmen/utils_spec.rb
+++ b/spec/carmen/utils_spec.rb
@@ -21,7 +21,7 @@ describe 'Utils.merge_arrays_by_keys' do
 
     merged = Carmen::Utils.merge_arrays_by_keys([first, second], ['code'])
 
-    merged.must_equal(expected)
+    _(merged).must_equal(expected)
   end
 end
 
@@ -33,7 +33,7 @@ describe 'Utils.deep_hash_merge' do
 
     expected = { 'a' => 'old', 'b' => 'new', 'c' => 'old', 'd' => 'new' }
 
-    Carmen::Utils.deep_hash_merge([first, second]).must_equal(expected)
+    _(Carmen::Utils.deep_hash_merge([first, second])).must_equal(expected)
   end
 
 end

--- a/spec/carmen/world_spec.rb
+++ b/spec/carmen/world_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Carmen::World do
 
   it 'is the World' do
-    Carmen::World.instance.is_a?(Carmen::World).must_equal(true)
+    _(Carmen::World.instance.is_a?(Carmen::World)).must_equal(true)
   end
 
   it 'has 3 subregions' do
-    Carmen::World.instance.subregions.size.must_equal(3)
+    _(Carmen::World.instance.subregions.size).must_equal(3)
   end
 
 end


### PR DESCRIPTION
This trivial PR fixes all the deprecation warnings emitted by MiniTest.