### PR TITLE
gemspec: Unpin rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+language: ruby
 rvm:
-  - 2.4.0
-  - 2.5.0
-  - 2.6.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
   - ruby-head
-before_install:
-  - gem install bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/carmen.gemspec
+++ b/carmen.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.files = Dir.glob("{lib,iso_data,locale}/**/*") + %w(MIT-LICENSE README.md CHANGELOG.md)
 
-  s.add_development_dependency('rake', '0.9.2.2')
+  s.add_development_dependency('rake')
   s.add_development_dependency('i18n')
   s.add_dependency('activesupport', '>= 3.0.0')
 end


### PR DESCRIPTION
There was a failure with Ruby 2.5.0 trying to `require` URI::Generic. This happened inside rake, and this commit is an attempt to avoid that by picking any rake available.

